### PR TITLE
Remove the extra top padding of list while iOS version >= 15.0

### DIFF
--- a/Sources/AltSwiftUI/Source/Views/Collections/List.swift
+++ b/Sources/AltSwiftUI/Source/Views/Collections/List.swift
@@ -358,6 +358,9 @@ extension List: Renderable {
             view.estimatedRowHeight = rowHeight
         }
         view.showsVerticalScrollIndicator = showsIndicators
+        if #available(iOS 15.0, *) {
+            view.sectionHeaderTopPadding = 0.0
+        }
         return delegate
     }
     


### PR DESCRIPTION
#### Reference
- https://stackoverflow.com/questions/68155090/extra-padding-above-table-view-headers-in-ios-15